### PR TITLE
:construction_worker: add CI to commits in main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on:
   pull_request:
+  push:
+    branches:
+      - main
 
 defaults:
   run:


### PR DESCRIPTION
Hey!
I realized after you merged #1 that you also do pushes to main. With this new trigger:

```yaml
  push:
    branches:
      - main
```

should run the CI job on every commit to `main`, not only on pull requests (like this one)